### PR TITLE
Partition assignment changes for subscribe feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 group 'io.zyient.framework'
-var versionName = '3.0.86-SNAPSHOT'
+var versionName = '3.0.87-SNAPSHOT'
 version = versionName
 configurations.all {
     exclude module: "logback-classic"

--- a/messaging/src/main/java/io/zyient/core/messaging/kafka/BaseKafkaConsumer.java
+++ b/messaging/src/main/java/io/zyient/core/messaging/kafka/BaseKafkaConsumer.java
@@ -21,6 +21,7 @@ import io.zyient.base.common.messaging.MessagingError;
 import io.zyient.base.common.model.Context;
 import io.zyient.base.common.utils.DefaultLogger;
 import io.zyient.base.core.connections.kafka.BasicKafkaConsumerConnection;
+import io.zyient.base.core.connections.settings.kafka.KafkaSettings;
 import io.zyient.base.core.processing.ProcessorState;
 import io.zyient.base.core.state.Offset;
 import io.zyient.base.core.state.OffsetState;
@@ -161,6 +162,10 @@ public abstract class BaseKafkaConsumer<M> extends MessageReceiver<String, M> {
     }
 
     private void initializeStates() throws Exception {
+        KafkaSettings ks = (KafkaSettings) consumer.settings();
+        if(ks.getPartitions().size() == 1 && ks.getPartitions().get(0) < 0) {
+            consumer.consumer().poll(Duration.ofMillis(1000));
+        }
         Set<TopicPartition> partitions = consumer.consumer().assignment();
         if (partitions == null || partitions.isEmpty()) {
             throw new MessagingError(String.format("No assigned partitions found. [name=%s][topic=%s]",


### PR DESCRIPTION
Partition assigned only after polling - if we don't call polling while initializing states then in case of consumer.subscribe() when consumer tries to fetch its assigned partition then it throws error of no partition assigned